### PR TITLE
🔧 Fix password nullable constraint for Google users

### DIFF
--- a/src/migrations/1700000000011-FixPasswordNullable.ts
+++ b/src/migrations/1700000000011-FixPasswordNullable.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixPasswordNullable1700000000011 implements MigrationInterface {
+  name = 'FixPasswordNullable1700000000011';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "password" DROP NOT NULL`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "password" SET NOT NULL`
+    );
+  }
+}


### PR DESCRIPTION
✅ Added migration to make password column nullable ✅ Allows Google users to sign up without passwords ✅ Fixes database constraint error for Google OAuth ✅ Migration: 1700000000011-FixPasswordNullable

This fixes the 'null value in column password violates not-null constraint' error.